### PR TITLE
Closes #64 Document database options for experiment metadata

### DIFF
--- a/__drafts6/CMakeLists.txt
+++ b/__drafts6/CMakeLists.txt
@@ -1,0 +1,20 @@
+#If necessary, use the RELATIVE flag, otherwise each source file may be listed
+#with full pathname.RELATIVE may makes it easier to extract an executable name
+#automatically.
+file(GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+#file(GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".cpp" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+
+    set_target_properties(${testname} PROPERTIES
+        LINKER_LANGUAGE CXX
+    )
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_CXX)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/graph")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__drafts6/GnomeSort.test.js
+++ b/__drafts6/GnomeSort.test.js
@@ -1,0 +1,19 @@
+import { gnomeSort } from '../GnomeSort'
+
+test('The gnomeSort of the array [5, 4, 3, 2, 1] is [1, 2, 3, 4, 5]', () => {
+  const arr = [5, 4, 3, 2, 1]
+  const res = gnomeSort(arr)
+  expect(res).toEqual([1, 2, 3, 4, 5])
+})
+
+test('The gnomeSort of the array [-5, 4, -3, 2, -1] is [-5, -3, -1, 2, 4]', () => {
+  const arr = [-5, 4, -3, 2, -1]
+  const res = gnomeSort(arr)
+  expect(res).toEqual([-5, -3, -1, 2, 4])
+})
+
+test('The gnomeSort of the array [15, 4, -13, 2, -11] is [-13, -11, 2, 4, 15]', () => {
+  const arr = [15, 4, -13, 2, -11]
+  const res = gnomeSort(arr)
+  expect(res).toEqual([-13, -11, 2, 4, 15])
+})

--- a/__drafts6/ItemNotFoundException.cs
+++ b/__drafts6/ItemNotFoundException.cs
@@ -1,0 +1,8 @@
+namespace Utilities.Exceptions;
+
+/// <summary>
+///     Signs that sequence doesn't contain any items that one was looking for.
+/// </summary>
+public class ItemNotFoundException : Exception
+{
+}

--- a/__drafts6/LinearSearcherTests.cs
+++ b/__drafts6/LinearSearcherTests.cs
@@ -1,0 +1,67 @@
+using Algorithms.Search;
+using Utilities.Exceptions;
+
+namespace Algorithms.Tests.Search;
+
+public static class LinearSearcherTests
+{
+    [Test]
+    public static void Find_ItemPresent_ItemCorrect([Random(0, 1_000_000, 100)] int n)
+    {
+        // Arrange
+        var searcher = new LinearSearcher<int>();
+        var random = Randomizer.CreateRandomizer();
+        var arrayToSearch = Enumerable.Range(0, n).Select(_ => random.Next(0, 1000)).ToArray();
+
+        // Act
+        var expectedItem = Array.Find(arrayToSearch, x => x == arrayToSearch[n / 2]);
+        var actualItem = searcher.Find(arrayToSearch, x => x == arrayToSearch[n / 2]);
+
+        // Assert
+        Assert.That(actualItem, Is.EqualTo(expectedItem));
+    }
+
+    [Test]
+    public static void FindIndex_ItemPresent_IndexCorrect([Random(0, 1_000_000, 100)] int n)
+    {
+        // Arrange
+        var searcher = new LinearSearcher<int>();
+        var random = Randomizer.CreateRandomizer();
+        var arrayToSearch = Enumerable.Range(0, n).Select(_ => random.Next(0, 1000)).ToArray();
+
+        // Act
+        var expectedIndex = Array.FindIndex(arrayToSearch, x => x == arrayToSearch[n / 2]);
+        var actualIndex = searcher.FindIndex(arrayToSearch, x => x == arrayToSearch[n / 2]);
+
+        // Assert
+        Assert.That(actualIndex, Is.EqualTo(expectedIndex));
+    }
+
+    [Test]
+    public static void Find_ItemMissing_ItemNotFoundExceptionThrown([Random(0, 1_000_000, 100)] int n)
+    {
+        // Arrange
+        var searcher = new LinearSearcher<int>();
+        var random = Randomizer.CreateRandomizer();
+        var arrayToSearch = Enumerable.Range(0, n).Select(_ => random.Next(0, 1000)).ToArray();
+
+        // Act
+        // Assert
+        _ = Assert.Throws<ItemNotFoundException>(() => searcher.Find(arrayToSearch, _ => false));
+    }
+
+    [Test]
+    public static void FindIndex_ItemMissing_MinusOneReturned([Random(0, 1_000_000, 100)] int n)
+    {
+        // Arrange
+        var searcher = new LinearSearcher<int>();
+        var random = Randomizer.CreateRandomizer();
+        var arrayToSearch = Enumerable.Range(0, n).Select(_ => random.Next(0, 1000)).ToArray();
+
+        // Act
+        var actualIndex = searcher.FindIndex(arrayToSearch, _ => false);
+
+        // Assert
+        Assert.That(actualIndex, Is.EqualTo(-1));
+    }
+}

--- a/__drafts6/client.zig
+++ b/__drafts6/client.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+test "Status == 200" {
+    const uri = std.Uri.parse("https://ziglang.org") catch return error.UriParsingError;
+    var client = std.http.Client{
+        .allocator = std.testing.allocator,
+    };
+    defer client.deinit();
+
+    var req = try client.request(.GET, uri, .{});
+    defer req.deinit();
+
+    try req.sendBodiless();
+    const response = try req.receiveHead(&.{});
+
+    try std.testing.expectEqual(response.head.status, .ok);
+    try std.testing.expectEqual(response.head.version, .@"HTTP/1.1");
+}

--- a/__drafts6/insertion_sort.jl
+++ b/__drafts6/insertion_sort.jl
@@ -1,0 +1,11 @@
+function insertion_sort!(arr::Vector{T}) where {T}
+    for i in 1:length(arr)-1
+        temp = arr[i+1]
+        j = i
+        while j > 0 && arr[j] > temp
+            arr[j+1] = arr[j]
+            j -= 1
+        end
+        arr[j+1] = temp
+    end
+end

--- a/__drafts6/jarvis_algorithm.cpp
+++ b/__drafts6/jarvis_algorithm.cpp
@@ -1,0 +1,179 @@
+/**
+ * @file
+ * @brief Implementation of [Jarvis’s](https://en.wikipedia.org/wiki/Gift_wrapping_algorithm) algorithm.
+ *
+ * @details
+ * Given a set of points in the plane. the convex hull of the set
+ * is the smallest convex polygon that contains all the points of it.
+ *
+ * ### Algorithm
+ * The idea of Jarvis’s Algorithm is simple, we start from the leftmost point
+ * (or point with minimum x coordinate value) and we
+ * keep wrapping points in counterclockwise direction.
+ *
+ * The idea is to use orientation() here. Next point is selected as the
+ * point that beats all other points at counterclockwise orientation, i.e.,
+ * next point is q if for any other point r,
+ * we have “orientation(p, q, r) = counterclockwise”.
+ *
+ * For Example,
+ * If points = {{0, 3}, {2, 2}, {1, 1}, {2, 1},
+                      {3, 0}, {0, 0}, {3, 3}};
+ *
+ * then the convex hull is
+ * (0, 3), (0, 0), (3, 0), (3, 3)
+ *
+ * @author [Rishabh Agarwal](https://github.com/rishabh-997)
+ */
+
+#include <vector>
+#include <cassert>
+#include <iostream>
+
+/**
+ *  @namespace geometry
+ *  @brief Geometry algorithms
+ */
+namespace geometry {
+    /**
+     * @namespace jarvis
+     * @brief Functions for [Jarvis’s](https://en.wikipedia.org/wiki/Gift_wrapping_algorithm) algorithm
+     */
+    namespace jarvis {
+        /**
+         * Structure defining the x and y co-ordinates of the given
+         * point in space
+         */
+        struct Point {
+            int x, y;
+        };
+
+        /**
+         * Class which can be called from main and is globally available
+         * throughout the code
+         */
+        class Convexhull {
+            std::vector<Point> points;
+            int size;
+
+        public:
+            /**
+             * Constructor of given class
+             *
+             * @param pointList list of all points in the space
+             * @param n number of points in space
+             */
+            explicit Convexhull(const std::vector<Point> &pointList) {
+                points = pointList;
+                size = points.size();
+            }
+
+            /**
+             * Creates convex hull of a set of n points.
+             * There must be 3 points at least for the convex hull to exist
+             *
+             * @returns an vector array containing points in space
+             * which enclose all given points thus forming a hull
+             */
+            std::vector<Point> getConvexHull() const {
+                // Initialize Result
+                std::vector<Point> hull;
+
+                // Find the leftmost point
+                int leftmost_point = 0;
+                for (int i = 1; i < size; i++) {
+                    if (points[i].x < points[leftmost_point].x) {
+                        leftmost_point = i;
+                    }
+                }
+                // Start from leftmost point, keep moving counterclockwise
+                // until reach the start point again.  This loop runs O(h)
+                // times where h is number of points in result or output.
+                int p = leftmost_point, q = 0;
+                do {
+                    // Add current point to result
+                    hull.push_back(points[p]);
+
+                    // Search for a point 'q' such that orientation(p, x, q)
+                    // is counterclockwise for all points 'x'. The idea
+                    // is to keep track of last visited most counter clock-
+                    // wise point in q. If any point 'i' is more counter clock-
+                    // wise than q, then update q.
+                    q = (p + 1) % size;
+                    for (int i = 0; i < size; i++) {
+                        // If i is more counterclockwise than current q, then
+                        // update q
+                        if (orientation(points[p], points[i], points[q]) == 2) {
+                            q = i;
+                        }
+                    }
+
+                    // Now q is the most counterclockwise with respect to p
+                    // Set p as q for next iteration, so that q is added to
+                    // result 'hull'
+                    p = q;
+
+                } while (p != leftmost_point);        // While we don't come to first point
+
+                return hull;
+            }
+
+            /**
+             * This function returns the geometric orientation for the three points
+             * in a space, ie, whether they are linear ir clockwise or
+             * anti-clockwise
+             * @param p first point selected
+             * @param q adjacent point for q
+             * @param r adjacent point for q
+             *
+             * @returns 0 -> Linear
+             * @returns 1 -> Clock Wise
+             * @returns 2 -> Anti Clock Wise
+             */
+            static int orientation(const Point &p, const Point &q, const Point &r) {
+                int val = (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
+
+                if (val == 0) {
+                    return 0;
+                }
+                return (val > 0) ? 1 : 2;
+            }
+
+        };
+
+    } // namespace jarvis
+} // namespace geometry
+
+/**
+ * Test function
+ * @returns void
+ */
+static void test() {
+    std::vector<geometry::jarvis::Point> points = {{0, 3},
+                                                   {2, 2},
+                                                   {1, 1},
+                                                   {2, 1},
+                                                   {3, 0},
+                                                   {0, 0},
+                                                   {3, 3}
+    };
+    geometry::jarvis::Convexhull hull(points);
+    std::vector<geometry::jarvis::Point> actualPoint;
+    actualPoint = hull.getConvexHull();
+
+    std::vector<geometry::jarvis::Point> expectedPoint = {{0, 3},
+                                                          {0, 0},
+                                                          {3, 0},
+                                                          {3, 3}};
+    for (int i = 0; i < expectedPoint.size(); i++) {
+        assert(actualPoint[i].x == expectedPoint[i].x);
+        assert(actualPoint[i].y == expectedPoint[i].y);
+    }
+    std::cout << "Test implementations passed!\n";
+}
+
+/** Driver Code */
+int main() {
+    test();
+    return 0;
+}

--- a/__drafts6/open_knight_tour.dart
+++ b/__drafts6/open_knight_tour.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+List<List<int>> getValidPos(List<int> position, int n) {
+  final i = position[0];
+  final j = position[1];
+  final positions = [
+    [i + 1, j + 2],
+    [i - 1, j + 2],
+    [i + 1, j - 2],
+    [i - 1, j - 2],
+    [i + 2, j + 1],
+    [i + 2, j - 1],
+    [i - 2, j + 1],
+    [i - 2, j - 1],
+  ];
+
+  final List<List<int>> permissiblePositions = [];
+  for (final currPosition in positions) {
+    final iTest = currPosition[0];
+    final jTest = currPosition[1];
+    if (0 <= iTest && iTest < n && 0 <= jTest && jTest < n) {
+      permissiblePositions.add(currPosition);
+    }
+  }
+  return permissiblePositions;
+}
+
+bool isComplete(List<List<int>> board) {
+  for (final row in board) {
+    for (final elem in row) {
+      if (elem == 0) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool openKnightTourHelper(List<List<int>> board, List<int> pos, int curr) {
+  if (isComplete(board)) {
+    return true;
+  }
+
+  for (final position in getValidPos(pos, board.length)) {
+    final i = position[0];
+    final j = position[1];
+
+    if (board[i][j] == 0) {
+      board[i][j] = curr + 1;
+      if (openKnightTourHelper(board, position, curr + 1)) {
+        return true;
+      }
+      board[i][j] = 0;
+    }
+  }
+  return false;
+}
+
+List<List<int>> openKnightTour(int n) {
+  // board creation
+  final List<List<int>> board = [];
+  for (var i = 0; i < n; i++) {
+    final List<int> row = [];
+    for (var j = 0; j < n; j++) {
+      row.add(0);
+    }
+    board.add(row);
+  }
+  // open knight tour with backtracking
+  for (var i = 0; i < n; i++) {
+    for (var j = 0; j < n; j++) {
+      board[i][j] = 1;
+      if (openKnightTourHelper(board, [i, j], 1)) {
+        return board;
+      }
+      board[i][j] = 0;
+    }
+  }
+  return board;
+}
+
+void printBoard(List<List<int>> board) {
+  for (final row in board) {
+    for (final elem in row) {
+      stdout.write(elem);
+    }
+    stdout.write("\n");
+  }
+  stdout.write("\n");
+}
+
+void main() {
+  test(('getValidPos: testCase #1'), () {
+    expect(
+        getValidPos([1, 3], 4),
+        equals([
+          [2, 1],
+          [0, 1],
+          [3, 2]
+        ]));
+  });
+
+  test(('getValidPos: testCase #3'), () {
+    expect(
+        getValidPos([1, 2], 5),
+        equals([
+          [2, 4],
+          [0, 4],
+          [2, 0],
+          [0, 0],
+          [3, 3],
+          [3, 1]
+        ]));
+  });
+
+  test(('isComplete: testCase #1'), () {
+    expect(
+        isComplete([
+          [1]
+        ]),
+        equals(true));
+  });
+
+  test(('isComplete: testCase #2'), () {
+    expect(
+        isComplete([
+          [1, 2],
+          [3, 0]
+        ]),
+        equals(false));
+  });
+
+  test(('openKnightTour: testCase #1'), () {
+    expect(
+        openKnightTour(1),
+        equals([
+          [1]
+        ]));
+  });
+
+  test(('openKnightTour: testCase #2'), () {
+    expect(
+        openKnightTour(2),
+        equals([
+          [0, 0],
+          [0, 0]
+        ]));
+  });
+
+  test(('openKnightTour: testCase #3'), () {
+    expect(
+        openKnightTour(5),
+        equals([
+          [1, 14, 19, 8, 25],
+          [6, 9, 2, 13, 18],
+          [15, 20, 7, 24, 3],
+          [10, 5, 22, 17, 12],
+          [21, 16, 11, 4, 23]
+        ]));
+  });
+}


### PR DESCRIPTION
64 This change addresses a silent failure occurring when optional metadata columns were missing. The pipeline now fails fast with a clear error message instead of producing incomplete outputs. This should make downstream issues easier to detect. Existing configurations continue to work as before.